### PR TITLE
Remove deprecated `trustedProxies` section

### DIFF
--- a/networking/authentication-required-when-accessing-stash-from-the-internet.md
+++ b/networking/authentication-required-when-accessing-stash-from-the-internet.md
@@ -30,8 +30,3 @@ You may use several methods to safely access Stash from outside of your home net
 ## Using an external authentication provider
 
 If you are an advanced user, and have secured your Stash instance behind an authwall provided by a reverse proxy or hosting solution, you may continue to use that. You simply have to edit `.stash/config/config.yml` and set `dangerous_allow_public_without_auth` to `true`. If you have already tripped the security feature, you will also have to remove the `security_tripwire_accessed_from_public_internet` key in order to allow Stash to serve requests.
-
-## Using a reverse proxy located outside of your private network
-
-By default, all private IPs are trusted proxies, so you almost certainly do not need to edit your settings.
-However, if you are using a reverse proxy outside of your private network (uncommon), it should be added to `trustedProxies` in your Configuration tab to allow it to serve requests.


### PR DESCRIPTION
This option was removed in https://github.com/stashapp/stash/pull/2229