### PR TITLE
specify TrueNAS CORE in docs

### DIFF
--- a/getting-started/installation/freenas-truenas.md
+++ b/getting-started/installation/freenas-truenas.md
@@ -1,6 +1,6 @@
 ---
 layout: clean
-title: FreeNAS/TrueNAS
+title: FreeNAS/TrueNAS CORE
 nav_order: 6
 parent: Installation
 grand_parent: Getting Started


### PR DESCRIPTION
TrueNAS has been seperated/ rebraded to CORE and SCALE
CORE is based on FreeBSD and SCALE is based on Debian and k8s

SCALE does not have *BSD jails and instead only runs k8s charts so docs will have to be added for kubernetes

[forum reference](https://www.truenas.com/community/resources/welcome-to-truenas-scale-beginners-intro.208/)
