### PR TITLE
Improve readability of keyboard shortcuts

### DIFF
--- a/in-app-manual/keyboardshortcuts.md
+++ b/in-app-manual/keyboardshortcuts.md
@@ -206,6 +206,3 @@ parent: In-app Manual
 | <kbd>d</kbd> <kbd>d</kbd> | Delete Tag |
 | <kbd>,</kbd> | Expand/Collapse Details |
 | <kbd>Ctrl</kbd> + <kbd>v</kbd> | Paste Tag image |
-<!--stackedit_data:
-eyJoaXN0b3J5IjpbNzM4MDAzNjQ0XX0=
--->

--- a/in-app-manual/keyboardshortcuts.md
+++ b/in-app-manual/keyboardshortcuts.md
@@ -206,3 +206,6 @@ parent: In-app Manual
 | <kbd>d</kbd> <kbd>d</kbd> | Delete Tag |
 | <kbd>,</kbd> | Expand/Collapse Details |
 | <kbd>Ctrl</kbd> + <kbd>v</kbd> | Paste Tag image |
+<!--stackedit_data:
+eyJoaXN0b3J5IjpbNzM4MDAzNjQ0XX0=
+-->

--- a/in-app-manual/keyboardshortcuts.md
+++ b/in-app-manual/keyboardshortcuts.md
@@ -51,8 +51,8 @@ parent: In-app Manual
 | <kbd>→</kbd> | Next page of results |
 | <kbd>⇧ Shift</kbd> + <kbd>←</kbd> | Go to current results page -10 |
 | <kbd>⇧ Shift</kbd> + <kbd>→</kbd> | Go to current results page +10 |
-| <kbd>Ctrl</kbd> + <kbd>Home</kbd> | Go to first page of results |
-| <kbd>Ctrl</kbd> + <kbd>End</kbd> | Go to last page of results |
+| <kbd>Ctrl</kbd> + <kbd>Home ⤒</kbd> | Go to first page of results |
+| <kbd>Ctrl</kbd> + <kbd>End ⤓</kbd> | Go to last page of results |
 | <kbd>s</kbd> <kbd>a</kbd> | Select all on page |
 | <kbd>s</kbd> <kbd>n</kbd> | Unselect all |
 | <kbd>e</kbd> | Edit selected |

--- a/in-app-manual/keyboardshortcuts.md
+++ b/in-app-manual/keyboardshortcuts.md
@@ -19,190 +19,190 @@ parent: In-app Manual
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `?` | Display manual |
+| <kbd>?</kbd> | Display manual |
 
 ## Global Navigation
 
 | Keyboard sequence | Target page |
 |-------------------|--------|
-| `g s` | Scenes |
-| `g i` | Images |
-| `g v` | Movies |
-| `g k` | Markers |
-| `g l` | Galleries |
-| `g p` | Performers |
-| `g u` | Studios |
-| `g t` | Tags |
-| `g z` | Settings |
+| <kbd>g</kbd> <kbd>s</kbd> | Scenes |
+| <kbd>g</kbd> <kbd>i</kbd> | Images |
+| <kbd>g</kbd> <kbd>v</kbd> | Movies |
+| <kbd>g</kbd> <kbd>k</kbd> | Markers |
+| <kbd>g</kbd> <kbd>l</kbd> | Galleries |
+| <kbd>g</kbd> <kbd>p</kbd> | Performers |
+| <kbd>g</kbd> <kbd>u</kbd> | Studios |
+| <kbd>g</kbd> <kbd>t</kbd> | Tags |
+| <kbd>g</kbd> <kbd>z</kbd> | Settings |
 
 # Query page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `/` | Focus search field / focus query field in filter dialog |
-| `f` | Show Add Filter dialog |
-| `r` | Reshuffle if sorted by random |
-| `v g` | Set view to grid |
-| `v l` | Set view to list |
-| `v w` | Set view to wall |
-| `+` | Increase zoom slider |
-| `-` | Decrease zoom slider |
-| `←` | Previous page of results |
-| `→` | Next page of results |
-| `Shift + ←` | Go to current results page -10 |
-| `Shift + →` | Go to current results page +10 |
-| `Ctrl + Home` | Go to first page of results |
-| `Ctrl + End` | Go to last page of results |
-| `s a` | Select all on page |
-| `s n` | Unselect all |
-| `e` | Edit selected |
-| `d d` | Delete selected |
+| <kbd>/</kbd> | Focus search field / focus query field in filter dialog |
+| <kbd>f</kbd> | Show Add Filter dialog |
+| <kbd>r</kbd> | Reshuffle if sorted by random |
+| <kbd>v</kbd> <kbd>g</kbd> | Set view to grid |
+| <kbd>v</kbd> <kbd>l</kbd> | Set view to list |
+| <kbd>v</kbd> <kbd>w</kbd> | Set view to wall |
+| <kbd>+</kbd> | Increase zoom slider |
+| <kbd>-</kbd> | Decrease zoom slider |
+| <kbd>←</kbd> | Previous page of results |
+| <kbd>→</kbd> | Next page of results |
+| <kbd>⇧ Shift</kbd> + <kbd>←</kbd> | Go to current results page -10 |
+| <kbd>⇧ Shift</kbd> + <kbd>→</kbd> | Go to current results page +10 |
+| <kbd>Ctrl</kbd> + <kbd>Home</kbd> | Go to first page of results |
+| <kbd>Ctrl</kbd> + <kbd>End</kbd> | Go to last page of results |
+| <kbd>s</kbd> <kbd>a</kbd> | Select all on page |
+| <kbd>s</kbd> <kbd>n</kbd> | Unselect all |
+| <kbd>e</kbd> | Edit selected |
+| <kbd>d</kbd> <kbd>d</kbd> | Delete selected |
 
 # Scenes page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `p r` | Play random scene |
+| <kbd>p</kbd> <kbd>r</kbd> | Play random scene |
 
 # Scene page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `a` | Details tab |
-| `q` | Queue tab |
-| `k` | Markers tab |
-| `i` | File info tab |
-| `e` | Edit tab |
-| `,` | Hide/Show sidebar |
-| `.` | Hide/Show scene scrubber |
-| `o` | Increment O-Counter |
-| `p n` | Play next scene in queue |
-| `p p` | Play previous scene in queue |
-| `p r` | Play random scene in queue |
-| `Space` | Play/pause player |
-| `Enter` | Play/pause player |
-| `←` | Seek backwards by 10 seconds |
-| `→` | Seek forwards by 10 seconds |
-| `Shift + ←` | Seek backwards by 5 seconds |
-| `Shift + →` | Seek forwards by 5 seconds |
-| `Ctrl/Alt + ←` | Seek backwards by 1 minute |
-| `Ctrl/Alt + →` | Seek forwards by 1 minute |
-| `{1-9}` | Seek to 10-90% duration |
-| `[` | Scrub backwards 10% duration |
-| `]` | Scrub forwards 10% duration |
-| `↑` | Increase volume 10% |
-| `↓` | Decrease volume 10% |
-| `m` | Toggle mute |
-| `l` | A/B looping toggle. Press once to set start point. Press again to set end point. Press again to disable loop. |
-| `Shift + l` | Toggle looping of scene when it's over |
+| <kbd>a</kbd> | Details tab |
+| <kbd>q</kbd> | Queue tab |
+| <kbd>k</kbd> | Markers tab |
+| <kbd>i</kbd> | File info tab |
+| <kbd>e</kbd> | Edit tab |
+| <kbd>,</kbd> | Hide/Show sidebar |
+| <kbd>.</kbd> | Hide/Show scene scrubber |
+| <kbd>o</kbd> | Increment O-Counter |
+| <kbd>p</kbd> <kbd>n</kbd> | Play next scene in queue |
+| <kbd>p</kbd> <kbd>p</kbd> | Play previous scene in queue |
+| <kbd>p</kbd> <kbd>r</kbd> | Play random scene in queue |
+| <kbd>Space ␣</kbd> | Play/pause player |
+| <kbd>Enter ↵</kbd> | Play/pause player |
+| <kbd>←</kbd> | Seek backwards by 10 seconds |
+| <kbd>→</kbd> | Seek forwards by 10 seconds |
+| <kbd>⇧ Shift</kbd> + <kbd>←</kbd> | Seek backwards by 5 seconds |
+| <kbd>⇧ Shift</kbd> + <kbd>→</kbd> | Seek forwards by 5 seconds |
+| <kbd>Ctrl</kbd> + <kbd>←</kbd><br />or<br /><kbd>⎇ Alt</kbd> + <kbd>←</kbd> | Seek backwards by 1 minute |
+| <kbd>Ctrl</kbd> + <kbd>→</kbd><br />or<br /><kbd>⎇ Alt</kbd> + <kbd>→</kbd> | Seek forwards by 1 minute |
+| <kbd>1</kbd>..<kbd>9</kbd> | Seek to 10-90% duration |
+| <kbd>[</kbd> | Scrub backwards 10% duration |
+| <kbd>]</kbd> | Scrub forwards 10% duration |
+| <kbd>↑</kbd> | Increase volume 10% |
+| <kbd>↓</kbd> | Decrease volume 10% |
+| <kbd>m</kbd> | Toggle mute |
+| <kbd>l</kbd> | A/B looping toggle. Press once to set start point. Press again to set end point. Press again to disable loop. |
+| <kbd>⇧ Shift</kbd> + <kbd>l</kbd> | Toggle looping of scene when it's over |
 
 ## Scene Markers tab shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `n` | Display Create Markers dialog |
+| <kbd>n</kbd> | Display Create Markers dialog |
 
 ## Edit Scene tab shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `r {1-5}` | Set rating (stars) |
-| `r 0` | Unset rating (stars) |
-| `r {0-9} {0-9}` | Set rating (decimal - `00` for `10.0`) |
-| ``r ` `` | Unset rating (decimal) |
-| `s s` | Save Scene |
-| `d d` | Delete Scene |
-| `Ctrl + v` | Paste Scene cover |
+| <kbd>r</kbd> <kbd>1</kbd>..<kbd>5</kbd> | Set rating (stars) |
+| <kbd>r</kbd> <kbd>0</kbd> | Unset rating (stars) |
+| <kbd>r</kbd> <kbd>0</kbd>..<kbd>9</kbd> <kbd>0</kbd>..<kbd>9</kbd> | Set rating (decimal - <kbd>r</kbd> <kbd>0</kbd> <kbd>0</kbd> for `10.0`) |
+| <kbd>r</kbd> <kbd>`</kbd> | Unset rating (decimal) |
+| <kbd>s</kbd> <kbd>s</kbd> | Save Scene |
+| <kbd>d</kbd> <kbd>d</kbd> | Delete Scene |
+| <kbd>Ctrl</kbd> + <kbd>v</kbd> | Paste Scene cover |
 
 [//]: # "Commented until implementation is dealt with"
-[//]: # "(| `l` | Focus Gallery selector |)"
-[//]: # "(| `u` | Focus Studio selector |)"
-[//]: # "(| `p` | Focus Performers selector |)"
-[//]: # "(| `v` | Focus Movies selector |)"
-[//]: # "(| `t` | Focus Tags selector |)"
+[//]: # "(| <kbd>l</kbd> | Focus Gallery selector |)"
+[//]: # "(| <kbd>u</kbd> | Focus Studio selector |)"
+[//]: # "(| <kbd>p</kbd> | Focus Performers selector |)"
+[//]: # "(| <kbd>v</kbd> | Focus Movies selector |)"
+[//]: # "(| <kbd>t</kbd> | Focus Tags selector |)"
 
 # Movies Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `n` | New Movie |
+| <kbd>n</kbd> | New Movie |
 
 # Movie Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `e` | Edit Movie |
-| `s s` | Save Movie |
-| `d d` | Delete Movie |
-| `r {1-5}` | [Edit mode] Set rating (stars) |
-| `r 0` | [Edit mode] Unset rating (stars) |
-| `r {0-9} {0-9}` | [Edit mode] Set rating (decimal - `r 0 0` for `10.0`) |
-| ``r ` `` | [Edit mode] Unset rating (decimal) |
-| `,` | Expand/Collapse Details |
-| `Ctrl + v` | Paste Movie image |
+| <kbd>e</kbd> | Edit Movie |
+| <kbd>s</kbd> <kbd>s</kbd> | Save Movie |
+| <kbd>d</kbd> <kbd>d</kbd> | Delete Movie |
+| <kbd>r</kbd> <kbd>1</kbd>..<kbd>5</kbd> | [Edit mode] Set rating (stars) |
+| <kbd>r</kbd> <kbd>0</kbd> | [Edit mode] Unset rating (stars) |
+| <kbd>r</kbd> <kbd>0</kbd>..<kbd>9</kbd> <kbd>0</kbd>..<kbd>9</kbd> | [Edit mode] Set rating (decimal - <kbd>r</kbd> <kbd>0</kbd> <kbd>0</kbd> for `10.0`) |
+| <kbd>r</kbd> <kbd>`</kbd> | [Edit mode] Unset rating (decimal) |
+| <kbd>,</kbd> | Expand/Collapse Details |
+| <kbd>Ctrl</kbd> + <kbd>v</kbd> | Paste Movie image |
 
 [//]: # "Commented until implementation is dealt with"
-[//]: # "(| `u` | Focus Studio selector (in edit mode) |)"
+[//]: # "(| <kbd>u</kbd> | Focus Studio selector (in edit mode) |)"
 
 # Markers Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `p r` | Play random marker |
+| <kbd>p</kbd> <kbd>r</kbd> | Play random marker |
 
 # Performers Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `n` | New Performer |
-| `p r` | Open random Performer |
+| <kbd>n</kbd> | New Performer |
+| <kbd>p</kbd> <kbd>r</kbd> | Open random Performer |
 
 # Performer Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `c` | Scenes tab |
-| `e` | Edit tab |
-| `o` | Operations tab |
-| `f` | Toggle favourite |
-| `,` | Expand/Collapse Details |
+| <kbd>c</kbd> | Scenes tab |
+| <kbd>e</kbd> | Edit tab |
+| <kbd>o</kbd> | Operations tab |
+| <kbd>f</kbd> | Toggle favourite |
+| <kbd>,</kbd> | Expand/Collapse Details |
 
 ## Edit Performer tab shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `s s` | Save Performer |
-| `d d` | Delete Performer |
-| `Ctrl + v` | Paste Performer image |
+| <kbd>s</kbd> <kbd>s</kbd> | Save Performer |
+| <kbd>d</kbd> <kbd>d</kbd> | Delete Performer |
+| <kbd>Ctrl</kbd> + <kbd>v</kbd> | Paste Performer image |
 
 # Studios Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `n` | New Studio |
+| <kbd>n</kbd> | New Studio |
 
 # Studio Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `e` | Edit Studio |
-| `s s` | Save Studio |
-| `d d` | Delete Studio |
-| `,` | Expand/Collapse Details |
-| `Ctrl + v` | Paste Studio image |
+| <kbd>e</kbd> | Edit Studio |
+| <kbd>s</kbd> <kbd>s</kbd> | Save Studio |
+| <kbd>d</kbd> <kbd>d</kbd> | Delete Studio |
+| <kbd>,</kbd> | Expand/Collapse Details |
+| <kbd>Ctrl</kbd> + <kbd>v</kbd> | Paste Studio image |
 
 # Tags Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `n` | New Tag |
+| <kbd>n</kbd> | New Tag |
 
 # Tag Page shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `e` | Edit Tag |
-| `s s` | Save Tag |
-| `d d` | Delete Tag |
-| `,` | Expand/Collapse Details |
-| `Ctrl + v` | Paste Tag image |
+| <kbd>e</kbd> | Edit Tag |
+| <kbd>s</kbd> <kbd>s</kbd> | Save Tag |
+| <kbd>d</kbd> <kbd>d</kbd> | Delete Tag |
+| <kbd>,</kbd> | Expand/Collapse Details |
+| <kbd>Ctrl</kbd> + <kbd>v</kbd> | Paste Tag image |


### PR DESCRIPTION
Having seen some discussions on Discord about making things easier for new users, and improving documentation, I was inspired to polish the keyboard shortcuts to look more like those on GitHub.

|  | [Docs Website](https://docs.stashapp.cc/in-app-manual/keyboardshortcuts/) | In-App Manual |
| - | - | - |
| **Before** | ![image](https://github.com/stashapp/Stash-Docs/assets/141467399/eb677d6d-02ac-4ce7-8981-2b105c7253d7) | ![image](https://github.com/stashapp/Stash-Docs/assets/141467399/9e024cfd-9ec9-4c9b-996d-9fc41b69c3c7) |
| **After** | (TBD - rendering issue to investigate/fix) | ![image](https://github.com/stashapp/Stash-Docs/assets/141467399/a62d882a-e48e-4403-9cb6-d835ee8d66e0) |
