### PR TITLE
Update browsing.md, added note about saved filter sorting

### DIFF
--- a/in-app-manual/browsing.md
+++ b/in-app-manual/browsing.md
@@ -60,6 +60,8 @@ The current sorting field is shown next to the query text field, indicating the 
 
 Saved filters can be accessed with the bookmark button on the left of the query text field. The current filter can be saved by entering a filter name and clicking on the save button. Existing saved filters may be overwritten with the current filter by clicking on the save button next to the filter name. Saved filters may also be deleted by pressing the delete button next to the filter name.
 
+Saved filters are sorted alphabetically by title, with capitalized titles sorted first.
+
 ## Default filter
 
 The default filter for the top-level pages may be set to the current filter by clicking the `Set as default` button in the saved filter menu.


### PR DESCRIPTION
Added a note about the order of saved filters, specifically that filters with capitalized titles are sorted first.