### PR TITLE
Revert "Temporarily disable social plugin"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,8 +64,8 @@ plugins:
       branch: main
       enabled: !ENV [CI, false]
   - glightbox
-#  - social:
-#      enabled: !ENV [CI, false]
+  - social:
+      enabled: !ENV [CI, false]
   - redirects:
       redirect_maps:
         'metadata-sources/list.md': 'https://stashapp.github.io/CommunityScrapers'


### PR DESCRIPTION
Reverts stashapp/Stash-Docs#105

The issue is fixed in https://github.com/squidfunk/mkdocs-material/releases/tag/9.6.14